### PR TITLE
Fix loadjs to use window.baseUrl provided by LMS

### DIFF
--- a/edx_sga/static/js/src/edx_sga.js
+++ b/edx_sga/static/js/src/edx_sga.js
@@ -433,7 +433,7 @@ function StaffGradedAssignmentXBlock(runtime, element) {
     function loadjs(url) {
         $('<script>')
             .attr('type', 'text/javascript')
-            .attr('src', url)
+            .attr('src', (window.baseUrl || '/static/') + url)
             .appendTo(element);
     }
 
@@ -444,8 +444,8 @@ function StaffGradedAssignmentXBlock(runtime, element) {
          * jquery.ajaxfileupload instead.  But our XBlock uses
          * jquery.fileupload.
          */
-        loadjs('/static/js/vendor/jQuery-File-Upload/js/jquery.iframe-transport.js');
-        loadjs('/static/js/vendor/jQuery-File-Upload/js/jquery.fileupload.js');
+        loadjs('js/vendor/jQuery-File-Upload/js/jquery.iframe-transport.js');
+        loadjs('js/vendor/jQuery-File-Upload/js/jquery.fileupload.js');
         xblock($, _);
     } else {
         /**


### PR DESCRIPTION
## Change description

Fix `loadjs` to use window.baseUrl provided by LMS. Copied from [upstream fix](https://github.com/mitodl/edx-sga/pull/319)

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/RED-2314

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
