### PR TITLE
enable python 3.8 tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,8 @@ jobs:
         include:
           - python-version: 3.5
             tox-env: py35-django2
+          - python-version: 3.8
+            tox-env: py38-django2
 
     steps:
       - uses: actions/checkout@v2
@@ -23,7 +25,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip wheel setuptools
           python -m pip install virtualenv tox tox-pip-version
+      - name: python 3.8 needs to downgrade setuptools to deal with an old package
+        run: |
+          python -m pip install tox-setuptools-version
+        if: matrix.python-version == 3.8
       - name: "Run tox targets for ${{ matrix.python-version }}"
         run: "tox -e ${{ matrix.tox-env }}"

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py35-django2
+envlist = py{35,38}-django2
 
 [testenv]
 pip_version=pip==20.2.4
+setuptools_version = setuptools<58
 passenv =
     COVERAGE_DIR
     CI


### PR DESCRIPTION
prod is currently 3.5, but we should still maintain compatibility with the next version of Python that we're going to need to move to and avoid introducing changes that break that.
